### PR TITLE
Add Python trade normalization and analysis module

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -1,0 +1,378 @@
+"""
+投資成績分析システムの中核ロジックを実装したPythonモジュール。
+
+主な責務:
+- 約定履歴（fills）を仕様書に従って1トレード=1行へ正規化
+- pnl_pctとRを算出し、基本指標や条件別期待値を集計
+- J-Quantsの日足・指数データを取り込み、特徴量を付与
+
+pandas DataFrameを入力・出力として扱い、Notebookやバッチ処理どちらでも利用できるように設計。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, List, Literal, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+
+Side = Literal["Buy", "Sell"]
+
+
+class TradeNormalizationError(ValueError):
+    """約定データが仕様違反の場合に送出される例外。"""
+
+
+@dataclass
+class TradeResult:
+    trade_id: int
+    code: str
+    entry_date: datetime
+    exit_date: datetime
+    avg_entry_price: float
+    avg_exit_price: float
+    buy_amount: float
+    sell_amount: float
+    fee_amount: float
+    pnl_yen: float
+    pnl_pct: float
+    r_multiple: float
+    holding_days: int
+
+    def as_dict(self) -> dict:
+        return {
+            "trade_id": self.trade_id,
+            "code": self.code,
+            "entry_date": self.entry_date.date(),
+            "exit_date": self.exit_date.date(),
+            "avg_entry_price": self.avg_entry_price,
+            "avg_exit_price": self.avg_exit_price,
+            "buy_amount": self.buy_amount,
+            "sell_amount": self.sell_amount,
+            "fee_amount": self.fee_amount,
+            "pnl_yen": self.pnl_yen,
+            "pnl_pct": self.pnl_pct,
+            "R": self.r_multiple,
+            "holding_days": self.holding_days,
+        }
+
+
+def _validate_fills(df: pd.DataFrame) -> pd.DataFrame:
+    """仕様の必須列とサイドを検証し、ソート用インデックスを付与。"""
+
+    required = {
+        "trade_fill_id",
+        "code",
+        "side",
+        "exec_datetime",
+        "price",
+        "quantity",
+        "fee",
+    }
+    missing = required - set(df.columns)
+    if missing:
+        raise TradeNormalizationError(f"欠損列があります: {sorted(missing)}")
+
+    side_ok = {"Buy", "Sell"}
+    invalid_side = set(df["side"]) - side_ok
+    if invalid_side:
+        raise TradeNormalizationError(f"不正なsideがあります: {sorted(invalid_side)}")
+
+    if (df["quantity"] <= 0).any():
+        raise TradeNormalizationError("quantityは正の数である必要があります")
+
+    if not np.issubdtype(df["exec_datetime"].dtype, np.datetime64):
+        df = df.copy()
+        df["exec_datetime"] = pd.to_datetime(df["exec_datetime"])
+
+    df = df.copy()
+    df["_input_order"] = np.arange(len(df))
+    return df
+
+
+def normalize_trades(fills: pd.DataFrame) -> pd.DataFrame:
+    """
+    約定履歴を1トレード=1行へ正規化してトレードDataFrameを返す。
+
+    ルール:
+    - exec_datetime昇順で処理し、同一日時は入力順を優先。
+    - Buyで残高を積み上げ、Sellで残高0になった時点で1トレード成立。
+    - pnl_pct, Rは仕様の固定損切り8%に対して算出。
+
+    Parameters
+    ----------
+    fills : pd.DataFrame
+        trade_fill_id, code, side, exec_datetime, price, quantity, fee を含む約定データ。
+
+    Returns
+    -------
+    pd.DataFrame
+        trade_id, code, entry_date, exit_date, avg_entry_price, avg_exit_price,
+        buy_amount, sell_amount, fee_amount, pnl_yen, pnl_pct, R, holding_days を列にもつ。
+    """
+
+    df = _validate_fills(fills)
+    df = df.sort_values(["exec_datetime", "_input_order"]).reset_index(drop=True)
+
+    trades: List[TradeResult] = []
+    active: dict[str, dict] = {}
+    next_trade_id = 1
+
+    for _, row in df.iterrows():
+        code = row["code"]
+        side: Side = row["side"]
+        qty = float(row["quantity"])
+        price = float(row["price"])
+        fee = float(row.get("fee", 0.0))
+        exec_dt: datetime = row["exec_datetime"]
+
+        state = active.get(code)
+
+        if side == "Sell" and state is None:
+            raise TradeNormalizationError(f"Sell先行を検知しました: code={code}, exec_datetime={exec_dt}")
+
+        if side == "Buy":
+            if state is None:
+                state = {
+                    "trade_id": next_trade_id,
+                    "code": code,
+                    "buy_qty": 0.0,
+                    "sell_qty": 0.0,
+                    "buy_amount": 0.0,
+                    "sell_amount": 0.0,
+                    "fee_amount": 0.0,
+                    "entry_date": exec_dt,
+                    "last_exit": exec_dt,
+                }
+                next_trade_id += 1
+                active[code] = state
+
+            state["buy_qty"] += qty
+            state["buy_amount"] += price * qty
+            state["fee_amount"] += fee
+            state["entry_date"] = min(state["entry_date"], exec_dt)
+        else:  # Sell
+            if state is None:
+                raise TradeNormalizationError(f"Sell処理時にポジションがありません: code={code}")
+
+            new_qty = state["buy_qty"] - state["sell_qty"] - qty
+            if new_qty < -1e-9:
+                raise TradeNormalizationError(
+                    f"残高がマイナスになります: code={code}, exec_datetime={exec_dt}, quantity={qty}"
+                )
+
+            state["sell_qty"] += qty
+            state["sell_amount"] += price * qty
+            state["fee_amount"] += fee
+            state["last_exit"] = exec_dt
+
+            if abs(new_qty) < 1e-9:  # ポジション完結
+                avg_entry_price = state["buy_amount"] / state["buy_qty"]
+                avg_exit_price = state["sell_amount"] / state["sell_qty"] if state["sell_qty"] else 0.0
+                pnl_yen = state["sell_amount"] - state["buy_amount"] - state["fee_amount"]
+                pnl_pct = pnl_yen / state["buy_amount"] if state["buy_amount"] else 0.0
+                r_multiple = pnl_pct / 0.08  # 損切り-8%を基準にしたR
+                holding_days = (state["last_exit"].date() - state["entry_date"].date()).days
+
+                trades.append(
+                    TradeResult(
+                        trade_id=state["trade_id"],
+                        code=code,
+                        entry_date=state["entry_date"],
+                        exit_date=state["last_exit"],
+                        avg_entry_price=avg_entry_price,
+                        avg_exit_price=avg_exit_price,
+                        buy_amount=state["buy_amount"],
+                        sell_amount=state["sell_amount"],
+                        fee_amount=state["fee_amount"],
+                        pnl_yen=pnl_yen,
+                        pnl_pct=pnl_pct,
+                        r_multiple=r_multiple,
+                        holding_days=holding_days,
+                    )
+                )
+                active.pop(code, None)
+
+    if active:
+        open_codes = ", ".join(sorted(active.keys()))
+        raise TradeNormalizationError(f"クローズしていないトレードがあります: {open_codes}")
+
+    trade_df = pd.DataFrame([t.as_dict() for t in trades])
+    if not trade_df.empty:
+        trade_df = trade_df.sort_values(["entry_date", "trade_id"]).reset_index(drop=True)
+    return trade_df
+
+
+def compute_basic_metrics(trades: pd.DataFrame) -> pd.DataFrame:
+    """トレード全体の件数・勝率・平均リターン・平均Rなど基本指標を返す。"""
+    if trades.empty:
+        return pd.DataFrame([
+            {
+                "trades": 0,
+                "win_rate": np.nan,
+                "avg_return_pct": np.nan,
+                "avg_R": np.nan,
+                "max_losing_streak": np.nan,
+            }
+        ])
+
+    wins = (trades["pnl_pct"] > 0).sum()
+    losing_streak = _compute_max_losing_streak(trades["pnl_pct"].to_list())
+
+    return pd.DataFrame(
+        [
+            {
+                "trades": len(trades),
+                "win_rate": wins / len(trades),
+                "avg_return_pct": trades["pnl_pct"].mean(),
+                "avg_R": trades["R"].mean(),
+                "max_losing_streak": losing_streak,
+            }
+        ]
+    )
+
+
+def _compute_max_losing_streak(pnl_list: Sequence[float]) -> int:
+    max_streak = 0
+    current = 0
+    for pnl in pnl_list:
+        if pnl <= 0:
+            current += 1
+            max_streak = max(max_streak, current)
+        else:
+            current = 0
+    return max_streak
+
+
+def evaluate_by_conditions(trades: pd.DataFrame, condition_columns: Iterable[str]) -> pd.DataFrame:
+    """
+    条件（特徴量）別に平均Rなどを集計するユーティリティ。
+
+    Parameters
+    ----------
+    trades : pd.DataFrame
+        normalize_tradesで生成したDataFrameに特徴量列を追加したもの。
+    condition_columns : Iterable[str]
+        グルーピング対象の列名。複数指定するとクロス集計になる。
+    """
+    if trades.empty:
+        return pd.DataFrame()
+
+    grouped = trades.groupby(list(condition_columns))
+    summary = grouped.agg(
+        trades=("trade_id", "count"),
+        avg_R=("R", "mean"),
+        win_rate=("pnl_pct", lambda s: (s > 0).mean()),
+        avg_return_pct=("pnl_pct", "mean"),
+    )
+    return summary.reset_index().sort_values("avg_R", ascending=False)
+
+
+def attach_market_features(
+    trades: pd.DataFrame,
+    market: pd.DataFrame,
+    index_df: Optional[pd.DataFrame] = None,
+) -> pd.DataFrame:
+    """
+    エントリー日に紐づく特徴量を付与する。
+
+    - 52週高値更新フラグ: closeが過去252営業日のmaxを更新
+    - 出来高急増率: 当日出来高 ÷ 過去20日平均
+    - ギャップ率: 当日始値/前日終値 - 1
+    - 地合いフラグ: index_dfのcloseが25MAより上ならTrue
+    """
+    if trades.empty:
+        return trades
+
+    mkt = market.copy()
+    mkt["date"] = pd.to_datetime(mkt["date"])
+    mkt = mkt.sort_values(["code", "date"]).reset_index(drop=True)
+
+    mkt["prev_close"] = mkt.groupby("code")["close"].shift(1)
+    mkt["gap_rate"] = (mkt["open"] / mkt["prev_close"]) - 1
+    mkt["vol_ma20"] = mkt.groupby("code")["volume"].transform(lambda s: s.rolling(20, min_periods=1).mean())
+    mkt["volume_surge"] = mkt["volume"] / mkt["vol_ma20"]
+    mkt["high_52w"] = mkt.groupby("code")["close"].transform(lambda s: s.rolling(252, min_periods=1).max())
+    mkt["is_52w_high"] = mkt["close"] >= mkt["high_52w"]
+
+    features = mkt[["code", "date", "gap_rate", "volume_surge", "is_52w_high"]]
+
+    if index_df is not None and not index_df.empty:
+        idx = index_df.copy()
+        idx["date"] = pd.to_datetime(idx["date"])
+        idx = idx.sort_values("date")
+        if "ma_25" not in idx:
+            idx["ma_25"] = idx["close"].rolling(25, min_periods=1).mean()
+        idx["trend_flag"] = idx["close"] >= idx["ma_25"]
+        features = features.merge(idx[["date", "trend_flag"]], on="date", how="left")
+
+    trades = trades.copy()
+    trades["entry_date"] = pd.to_datetime(trades["entry_date"])
+    enriched = trades.merge(
+        features,
+        left_on=["code", "entry_date"],
+        right_on=["code", "date"],
+        how="left",
+    ).drop(columns=["date"], errors="ignore")
+
+    return enriched
+
+
+def demo_pipeline(fills: pd.DataFrame, market: pd.DataFrame, index_df: Optional[pd.DataFrame] = None) -> pd.DataFrame:
+    """
+    仕様書の処理フローを1本の関数で実行するサンプル。
+
+    1. 約定データをトレード単位に正規化
+    2. 市場データとマージして特徴量付与
+    3. 基本指標を別途算出可能
+    """
+    trades = normalize_trades(fills)
+    trades_with_features = attach_market_features(trades, market, index_df=index_df)
+    return trades_with_features
+
+
+if __name__ == "__main__":
+    # 簡易デモ用のダミーデータセット
+    fills_demo = pd.DataFrame(
+        [
+            {
+                "trade_fill_id": 1,
+                "code": "7203",
+                "side": "Buy",
+                "exec_datetime": "2024-01-05 09:00",
+                "price": 1000,
+                "quantity": 100,
+                "fee": 50,
+            },
+            {
+                "trade_fill_id": 2,
+                "code": "7203",
+                "side": "Sell",
+                "exec_datetime": "2024-01-10 10:00",
+                "price": 1080,
+                "quantity": 100,
+                "fee": 50,
+            },
+        ]
+    )
+
+    market_demo = pd.DataFrame(
+        [
+            {"date": "2024-01-04", "code": "7203", "open": 990, "high": 1010, "low": 980, "close": 995, "volume": 120000},
+            {"date": "2024-01-05", "code": "7203", "open": 995, "high": 1015, "low": 990, "close": 1005, "volume": 150000},
+            {"date": "2024-01-10", "code": "7203", "open": 1060, "high": 1090, "low": 1050, "close": 1085, "volume": 180000},
+        ]
+    )
+
+    index_demo = pd.DataFrame(
+        [
+            {"date": "2024-01-04", "index": "TOPIX", "close": 2400},
+            {"date": "2024-01-05", "index": "TOPIX", "close": 2410},
+            {"date": "2024-01-10", "index": "TOPIX", "close": 2450},
+        ]
+    )
+
+    trades = demo_pipeline(fills_demo, market_demo, index_df=index_demo)
+    print("トレード一覧:\n", trades)
+    print("基本指標:\n", compute_basic_metrics(trades))

--- a/index.html
+++ b/index.html
@@ -1,89 +1,260 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Progate</title>
-  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+  <title>投資成績分析システム 仕様書</title>
   <link rel="stylesheet" type="text/css" href="stylesheet.css">
 </head>
 <body>
-  <header>
-    <div class="container">
-      <div class="header-left">
-        <img class="logo" src="https://prog-8.com/images/html/advanced/main_logo.png">
+  <header class="page-header">
+    <div class="container header-container">
+      <div class="branding">
+        <div class="logo-mark" aria-hidden="true">R</div>
+        <div>
+          <p class="eyebrow">期待値最大化プロジェクト</p>
+          <h1>投資成績分析システム</h1>
+        </div>
       </div>
-      <span class="fa fa-bars menu-icon"></span>
-      <div class="header-right">
-        <a href="#">うんちレッスン</a>
-        <a href="#">新規登録</a>
-        <a href="#" class="login">ログイン</a>
-      </div>
+      <nav class="nav-links">
+        <a href="#purpose">目的</a>
+        <a href="#data">データ仕様</a>
+        <a href="#analysis">分析</a>
+        <a href="#policy">運用</a>
+      </nav>
     </div>
   </header>
-  <div class="top-wrapper">
-    <div class="container">
-      <h1>LEARN TO CODE.<br>LEARN TO BE CREATIVE.</h1>
-      <p>Progateはオンラインプログラミング学習サービスです。<br>初心者にもやさしいスライドとレッスンで、ウェブサービスを作りながらプログラミングを学んでいきましょう。</p>
-      <div class="btn-wrapper">
-        <a href="#" class="btn signup">新規登録はこちら</a>
-        <p>or</p>
-        <a href="#" class="btn facebook"><span class="fa fa-facebook"></span>Facebookで登録</a>
-        <a href="#" class="btn twitter"><span class="fa fa-twitter"></span>Twitterで登録</a>
-      </div>
-    </div>
-  </div>
-  <div class="lesson-wrapper">
-    <div class="container">
-      <div class="heading">
-        <h2>Learn Where to Get Started!</h2>
-      </div>
-      <div class="lessons">
-        <div class="lesson">
-          <div class="lesson-icon">
-            <img src="https://prog-8.com/images/html/advanced/html.png">
-            <p>HTML & CSS</p>
+
+  <main>
+    <section class="hero">
+      <div class="container hero-grid">
+        <div>
+          <p class="eyebrow">日本株 現物取引に最適化</p>
+          <h2>1トレードあたりの期待値（平均R）を最大化する</h2>
+          <p class="lede">過去の取引履歴と市場データを統合し、再現可能な高期待値トレードだけを実行するための仕様書です。月次・四半期での継続的な改善を前提とした運用設計を示します。</p>
+          <div class="pill-list">
+            <span class="pill">固定損切り -8%</span>
+            <span class="pill">平均Rで評価</span>
+            <span class="pill">定期見直し</span>
           </div>
-          <p class="text-contents">ウェブページの作成に使用される言語です。HTMLとCSSを組み合わせることで、静的なページを作り上げることができます。</p>
         </div>
-        <div class="lesson">
-          <div class="lesson-icon">
-            <img src="https://prog-8.com/images/html/advanced/jQuery.png">
-            <p>jQuery</p>
-          </div>
-          <p class="text-contents">素敵な動きを手軽に実装できるJavaScriptライブラリです。 アニメーション効果をつけたり、Ajax（エイジャックス）を使って外部ファイルを読み込んだりと色々なことができます。</p>
-        </div>
-        <div class="lesson">
-          <div class="lesson-icon">
-            <img src="https://prog-8.com/images/html/advanced/ruby.png">
-            <p>Ruby</p>
-          </div>
-          <p class="text-contents">オープンソースの動的なプログラミング言語で、 シンプルさと高い生産性を備えています。大きなWebアプリケーションから小さな日用ツールまで、さまざまなソフトウェアを作ることができます。</p>
-        </div>
-        <div class="lesson">
-          <div class="lesson-icon">
-            <img src="https://prog-8.com/images/html/advanced/php.png">
-            <p>PHP</p>
-          </div>
-          <p class="text-contents">HTMLだけではページの内容を変えることはできません。PHPはHTMLにプログラムを埋め込み、それを可能にします。</p>
+        <div class="card">
+          <h3>基本前提</h3>
+          <ul class="key-points">
+            <li>対象：日本株（現物）</li>
+            <li>損切り：-8% 固定</li>
+            <li>期待値：平均R = 実現リターン(%) ÷ 8%</li>
+            <li>1トレード：残高が0に戻るまでを1行で管理</li>
+          </ul>
         </div>
       </div>
-      <div class="clear"></div>
-    </div>
-  </div>
-  <div class="message-wrapper">
-    <div class="container">
-      <div class="heading">
-        <h2>さぁ、あなたもProgateでプログラミングを学んでみませんか?</h2>
-        <h3>Let's learn to code, learn to be creative!</h3>
+    </section>
+
+    <section id="purpose" class="section">
+      <div class="container">
+        <div class="section-heading">
+          <p class="eyebrow">Purpose</p>
+          <h2>目的</h2>
+        </div>
+        <div class="grid two-col">
+          <p>上手くいった／ダメだったトレードを定量的に分類し、期待値が高い条件のみを抽出して投資ルールへ落とし込みます。感覚的な売買判断を排除し、再現可能なプロセスを重視します。</p>
+          <div class="card highlight">
+            <h3>期待値の定義</h3>
+            <p class="formula">R = 実現リターン(%) ÷ 8%<br>期待値 = 平均R</p>
+            <p>トレードの成否は平均Rで測定し、0を下回る条件は採用しません。</p>
+          </div>
+        </div>
       </div>
-      <span class="btn message">さっそく開発する</span>
-    </div>
-  </div>
-  <footer>
-    <div class="container">
-      <img src="https://prog-8.com/images/html/advanced/footer_logo.png">
-      <p>Learn to Code, Learn to be Creative.</p>
+    </section>
+
+    <section class="section light">
+      <div class="container">
+        <div class="section-heading">
+          <p class="eyebrow">Architecture</p>
+          <h2>システム全体構成</h2>
+        </div>
+        <ol class="flow">
+          <li>証券会社の約定履歴を整形</li>
+          <li>トレード正規化（1トレード=1行）</li>
+          <li>J-Quantsの日足データを結合</li>
+          <li>特徴量を付与（地合い・出来高・ギャップ率など）</li>
+          <li>期待値分析・条件評価</li>
+          <li>投資方針・ルールを更新</li>
+        </ol>
+      </div>
+    </section>
+
+    <section id="data" class="section">
+      <div class="container">
+        <div class="section-heading">
+          <p class="eyebrow">Data Specs</p>
+          <h2>データ仕様</h2>
+        </div>
+
+        <div class="card">
+          <h3>トレード正規化ルール</h3>
+          <ul class="bullet-list">
+            <li><strong>1トレードの定義：</strong>同一銘柄でBuyにより残高が正になってから、Sellで0に戻るまで。</li>
+            <li>分割エントリー・分割利確は同一トレードに統合。</li>
+            <li><strong>処理順：</strong>exec_datetime昇順。同一日時は入力順。</li>
+            <li><strong>損益計算：</strong>pnl_yen = Σ(sell_price×qty) − Σ(buy_price×qty) − fee_amount</li>
+            <li>pnl_pct = pnl_yen ÷ buy_amount</li>
+            <li>R = pnl_pct ÷ 8%</li>
+            <li>Sell先行や残高マイナスは不整合として除外。</li>
+          </ul>
+        </div>
+
+        <div class="grid two-col data-grid">
+          <div class="card">
+            <h4>約定データ（証券会社）</h4>
+            <ul class="data-points">
+              <li>trade_fill_id, code, side (Buy/Sell)</li>
+              <li>exec_datetime, price, quantity, fee</li>
+              <li>account_type (NISA/特定/一般)</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h4>トレードデータ（分析用）</h4>
+            <ul class="data-points">
+              <li>trade_id, code, entry_date, exit_date</li>
+              <li>avg_entry_price, avg_exit_price</li>
+              <li>buy_amount, sell_amount, fee_amount</li>
+              <li>pnl_yen, pnl_pct, R, holding_days</li>
+              <li>peak_exposure（任意）</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h4>市場データ（J-Quants）</h4>
+            <ul class="data-points">
+              <li>date, code, open/high/low/close</li>
+              <li>volume, adj_close</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h4>市場環境データ</h4>
+            <ul class="data-points">
+              <li>index: TOPIX</li>
+              <li>close, ma_25</li>
+              <li>trend_flag: 上昇 / 下落</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h4>データ品質チェック</h4>
+            <ul class="data-points">
+              <li>Sell先行や残高マイナスの検知</li>
+              <li>手数料集計（約定単位→トレード単位）</li>
+              <li>タイムゾーン/日付のずれを正規化</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section light" id="features">
+      <div class="container">
+        <div class="section-heading">
+          <p class="eyebrow">Feature Engineering</p>
+          <h2>特徴量設計（エントリー時点）</h2>
+        </div>
+        <div class="pill-list">
+          <span class="pill">52週高値更新フラグ</span>
+          <span class="pill">直近高値ブレイク種別</span>
+          <span class="pill">出来高急増率（当日 ÷ 過去20日平均）</span>
+          <span class="pill">ギャップ率</span>
+          <span class="pill">ATR</span>
+          <span class="pill">移動平均乖離率</span>
+          <span class="pill">地合いフラグ（TOPIX×25MA）</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="analysis">
+      <div class="container">
+        <div class="section-heading">
+          <p class="eyebrow">Analysis</p>
+          <h2>分析仕様</h2>
+        </div>
+        <div class="grid two-col">
+          <div class="card">
+            <h3>基本指標</h3>
+            <ul class="bullet-list">
+              <li>トレード数 / 勝率 / 平均リターン(%)</li>
+              <li><strong>平均R（期待値）</strong></li>
+              <li>連敗数（任意）</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>条件別期待値分析</h3>
+            <p class="subtitle">特徴量ごとにグループ分けし平均Rを算出</p>
+            <ul class="bullet-list">
+              <li>出来高 ≥ 2倍 / &lt; 2倍</li>
+              <li>地合い良 / 悪</li>
+              <li>ブレイク種別別 など</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section light" id="policy">
+      <div class="container">
+        <div class="section-heading">
+          <p class="eyebrow">Operation</p>
+          <h2>投資方針と定期見直し</h2>
+        </div>
+        <div class="grid two-col">
+          <div class="card">
+            <h3>投資方針への落とし込み</h3>
+            <ul class="bullet-list">
+              <li>平均R ≤ 0 の条件は採用しない</li>
+              <li>平均Rが高い条件のみを組み合わせ（最大3つ）</li>
+              <li>目的は「トレード数削減」ではなく「期待値最大化」</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>定期見直し運用</h3>
+            <p class="subtitle">月次または四半期で実施</p>
+            <ol class="flow small">
+              <li>直近期間の条件別平均Rを再計算</li>
+              <li>期待値が低下した条件を1つ削除</li>
+              <li>新条件を1つだけ追加して検証（同時変更は避ける）</li>
+            </ol>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <div class="section-heading">
+          <p class="eyebrow">Output</p>
+          <h2>最終アウトプット</h2>
+        </div>
+        <div class="grid three-col outputs">
+          <div class="card">
+            <h3>投資条件一覧</h3>
+            <p>採用中の条件とその平均Rを明示し、実行可能な売買ルールとして管理。</p>
+          </div>
+          <div class="card">
+            <h3>資産曲線・期待値推移</h3>
+            <p>期間ごとの平均Rの変化を可視化し、ルールの陳腐化を検知します。</p>
+          </div>
+          <div class="card">
+            <h3>次期検証テーマ</h3>
+            <p>改善の仮説を1つだけ設定し、検証と学習を繰り返します。</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="page-footer">
+    <div class="container footer-content">
+      <div>
+        <p class="eyebrow">Goal</p>
+        <p><strong>再現可能な高期待値トレードのみ実行</strong></p>
+      </div>
+      <p class="tagline">Data-driven investing for resilient performance.</p>
     </div>
   </footer>
 </body>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -2,270 +2,301 @@
   box-sizing: border-box;
 }
 
+:root {
+  --bg-dark: #0f172a;
+  --bg-light: #f6f8fb;
+  --primary: #2563eb;
+  --accent: #38bdf8;
+  --text: #0b1021;
+  --muted: #5b6475;
+  --card: #ffffff;
+  --border: #e2e8f0;
+}
+
 body {
   margin: 0;
-  font-family: "Hiragino Kaku Gothic ProN";
+  font-family: "Helvetica Neue", "Hiragino Kaku Gothic ProN", sans-serif;
+  color: var(--text);
+  background: #ffffff;
+  line-height: 1.7;
 }
 
 a {
   text-decoration: none;
+  color: inherit;
 }
 
 .container {
-  width: 100%;
-  padding: 0 15px;
+  width: min(1100px, 100%);
+  padding: 0 24px;
   margin: 0 auto;
 }
 
-.top-wrapper {
-  padding: 180px 0 100px 0;
-  background-image: url(top.png);
-  background-size: cover;
-  color: white;
-  text-align: center;
-}
-
-.top-wrapper h1 {
-  opacity: 0.7;
-  font-size: 45px;
-  letter-spacing: 5px;
-}
-
-.top-wrapper p {
-  opacity: 0.7;
-  font-size: 16px;
-  margin-bottom: 40px;
-}
-
-.btn-wrapper {
-  text-align: center;
-}
-
-.btn-wrapper p {
-  margin-bottom: 20px;
-}
-
-.signup {
-  background-color: #239b76;
-}
-
-.facebook {
-  background-color: #3b5998;
-  margin-right: 10px;
-}
-
-.twitter {
-  background-color: #55acee;
-}
-
-.btn {
-  padding: 8px 24px;
-  color: white;
-  display: inline-block;
-  opacity: 0.8;
-  border-radius: 4px;
-  text-align: center;
-}
-
-.btn:hover {
-  opacity: 1;
-}
-
-.fa {
-  margin-right: 5px;
-}
-
-header {
-  height: 65px;
-  width: 100%;
-  background-color: rgba(34,49,52,0.9);
-  position :fixed;
+.page-header {
+  position: sticky;
   top: 0;
-  z-index: 10;
-}
-
-.logo {
-  width: 124px;
-  margin-top: 20px;
-}
-
-.header-left {
-  float: left;
-}
-
-.header-right {
-  float: right;
-  margin-right: -25px;
-}
-
-.header-right a {
-  line-height: 65px;
-  padding: 0 25px;
-  color: white;
-  display: block;
-  float: left;
-  transition: all 0.5s;
-}
-
-.header-right a:hover {
-  background-color: rgba(255,255,255,0.3);
-}
-
-.lesson-wrapper {
-  height: 580px;
-  padding-bottom: 80px;
-  padding-left: 5%;
-  padding-right: 5%;
-  background-color: #f7f7f7;
-  text-align: center;
-}
-
-.heading {
-  padding-top: 80px;
-  padding-bottom: 50px;
-  color: #5f5d60;
-}
-
-.heading h2 {
-  font-weight: normal;
-}
-
-.lesson {
-  float: left;
-  width: 25%;
-}
-
-.lesson-icon {
-  position: relative;
-}
-
-.lesson-icon p {
-  position: absolute;
-  top: 37%;
   width: 100%;
-  color: white;
+  background: rgba(255, 255, 255, 0.95);
+  border-bottom: 1px solid var(--border);
+  z-index: 10;
+  backdrop-filter: blur(10px);
 }
 
-.text-contents {
-  width: 80%;
-  display: inline-block;
-  margin-top: 15px;
-  font-size: 13px;
-  color: #b3aeb5;
+.header-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 0;
+  gap: 16px;
 }
 
-.heading h3 {
-  font-weight: normal;
+.branding {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
-.message-wrapper {
-  border-bottom: 1px solid #eee;
-  padding-bottom: 80px;
-  text-align: center;
+.logo-mark {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  color: #fff;
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+  font-size: 20px;
+  box-shadow: 0 10px 30px rgba(37, 99, 235, 0.25);
 }
 
-.message {
-  padding: 15px 40px;
-  background-color: #5dca88;
-  cursor: pointer;
-  box-shadow: 0px 7px #1a7940;
+h1 {
+  margin: 0;
+  font-size: 22px;
 }
 
-.message:active {
-  position: relative;
-  top: 7px;
-  box-shadow: none;
+.nav-links {
+  display: flex;
+  gap: 12px;
+  font-size: 14px;
+  color: var(--muted);
 }
 
-footer img {
-  width: 125px;
+.nav-links a {
+  padding: 8px 12px;
+  border-radius: 10px;
+  transition: background 0.2s ease, color 0.2s ease;
 }
 
-footer p {
-  color: #b3aeb5;
+.nav-links a:hover {
+  background: var(--bg-light);
+  color: var(--primary);
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 64px;
+}
+
+.hero {
+  background: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.2), transparent 30%),
+              radial-gradient(circle at 80% 30%, rgba(37, 99, 235, 0.2), transparent 35%),
+              linear-gradient(135deg, #f8fbff, #eef4ff);
+  padding: 96px 0 72px;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 32px;
+  align-items: start;
+}
+
+h2 {
+  margin: 8px 0;
+  font-size: 28px;
+}
+
+.lede {
+  color: var(--muted);
+  margin: 12px 0 18px;
+}
+
+.eyebrow {
   font-size: 12px;
+  color: var(--primary);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0;
 }
 
-footer {
-  padding-top: 30px;
-  padding-bottom: 20px;
+.pill-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 12px;
 }
 
-.menu-icon {
-  color: white;
-  float: right;
-  font-size: 25px;
-  padding: 21px 0;
-  display: none;
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 12px;
+  background: #e9f2ff;
+  color: var(--primary);
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
 }
 
-.clear {
-  clear: left;
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 15px 40px rgba(15, 23, 42, 0.06);
 }
 
-@media all and (max-width: 1000px) {
-  .lesson {
-    width: 50%;
-    margin-bottom: 50px;
-  }
-
-  .lesson-wrapper {
-    height: 990px;
-  }
-
-  footer {
-    text-align: center;
-  }
+.card.highlight {
+  background: linear-gradient(135deg, #f8fbff, #ffffff);
+  border-color: #d9e7ff;
 }
 
-@media all and (max-width: 750px) {
-  .top-wrapper h1 {
-    font-size: 32px;
-  }
-
-  .heading h2 {
-    font-size: 20px;
-  }
+.key-points {
+  margin: 12px 0 0;
+  padding-left: 18px;
+  color: var(--muted);
 }
 
-@media all and (max-width: 670px) {
-  .header-right {
+.section {
+  padding: 40px 0;
+}
+
+.section.light {
+  background: var(--bg-light);
+}
+
+.section-heading h2 {
+  margin: 4px 0 16px;
+}
+
+.grid {
+  display: grid;
+  gap: 24px;
+}
+
+.two-col {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.three-col {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.bullet-list {
+  margin: 12px 0 0;
+  padding-left: 18px;
+  color: var(--muted);
+}
+
+.flow {
+  counter-reset: step;
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.flow li {
+  position: relative;
+  padding: 12px 12px 12px 44px;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.05);
+}
+
+.flow li::before {
+  counter-increment: step;
+  content: counter(step);
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--primary);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.flow.small li {
+  padding: 10px 10px 10px 38px;
+}
+
+.subtitle {
+  color: var(--muted);
+  margin: 6px 0 12px;
+}
+
+.formula {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 10px 12px;
+  border-radius: 12px;
+  display: inline-block;
+  margin: 8px 0;
+  box-shadow: inset 0 0 0 1px rgba(226, 232, 240, 0.15);
+}
+
+.data-grid .card h4 {
+  margin: 0 0 8px;
+}
+
+.data-points {
+  margin: 0;
+  padding-left: 16px;
+  color: var(--muted);
+}
+
+.outputs p {
+  color: var(--muted);
+}
+
+.page-footer {
+  border-top: 1px solid var(--border);
+  background: #fff;
+  padding: 32px 0;
+}
+
+.footer-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.tagline {
+  margin: 0;
+  color: var(--muted);
+}
+
+@media (max-width: 720px) {
+  .nav-links {
     display: none;
   }
 
-  .menu-icon {
-    display: block;
-  }
-
-  .top-wrapper .btn {
-    width: 100%;
-  }
-
-  .twitter {
-    margin-top: 10px;
-  }
-
-  .top-wrapper {
-    text-align: left;
-  }
-
-  .top-wrapper h1 {
+  h2 {
     font-size: 24px;
   }
 
-  .top-wrapper p {
-    font-size: 14px;
-  }
-
-  .lesson {
-    width: 100%;
-  }
-
-  .lesson-wrapper {
-    height: 1700px;
-  }
-
-  .message-wrapper .btn {
-    width: 100%;
+  .hero {
+    padding: 72px 0 56px;
   }
 }


### PR DESCRIPTION
## Summary
- add pandas-based pipeline to normalize fills into trades with pnl_pct and R per spec
- provide basic metrics, condition grouping utilities, and feature attachment from J-Quants market data
- include demo pipeline showcasing end-to-end processing and validation errors for malformed inputs

## Testing
- python -m compileall analysis.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d70009dc48328b447cafb6e714c67)